### PR TITLE
Add library definition to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,17 @@ project(lia
         VERSION 1.0
         LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 option(LIA_BUILD_TESTS "Build the LIA tests" OFF)
+
+add_library(lia INTERFACE)
+
+target_include_directories(
+    lia
+    INTERFACE
+    "include/"
+)
 
 if (LIA_BUILD_TESTS)
     add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,17 +7,17 @@ set(SOURCES
   "QuaternionTest.cpp"
 )
 
-set(PROJECT_INCLUDE_DIRECTORIES
-    ${PROJECT_SOURCE_DIR}/include
-)
-
 set(APP_NAME LiaTests)
 
 add_executable(${APP_NAME} ${SOURCES})
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})
 
-target_include_directories(${APP_NAME} PRIVATE ${PROJECT_INCLUDE_DIRECTORIES} ${CMAKE_CURRENT_SOURCE_DIR}/"doctest.h")
+target_link_libraries(
+  ${APP_NAME}
+  PRIVATE
+  lia
+)
 
 set_target_properties(${APP_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
 


### PR DESCRIPTION
Related to: https://github.com/denyskryvytskyi/ElvenEngine/issues/32

This PR aims to configure correctly CMakeLists for lia, specifically the library definition, as currently, adding library to the project requires also manually configuring the include path.

This can be avoided by correctly invoking `add_library` and `target_include_directories` with INTERFACE scope.

Therefore, adding lia to existing CMake project simplifies from:
```cmake
FetchContent_Declare(
        lia
        GIT_REPOSITORY "https://github.com/denyskryvytskyi/lia.git"
        GIT_TAG "main"
)

FetchContent_MakeAvailable(lia)

target_include_directories(myTarget PRIVATE ${lia_SOURCE_DIR}/include)
```

to

```cmake
FetchContent_Declare(
        lia
        GIT_REPOSITORY "https://github.com/denyskryvytskyi/lia.git"
        GIT_TAG "main"
)

FetchContent_MakeAvailable(lia)

target_link_libraries(myTarget PRIVATE lia)
``` 

Although providing minimal visual effect, in reality this allows abstracting over the lia implementation details and letting CMake do all compiler/linking configurations just by invoking single and straightforward `target_link_libraries` call.

As a proof, I've also changed `tests` CMakeLists to link against the library, and it worked.